### PR TITLE
Update scripts for cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "scripts": {
     "start-prereqs": "docker run -d -p 5432:5432 --rm --name cardstack-pg cardstack/pg-test",
     "stop-prereqs": "docker stop cardstack-pg",
-    "start": "cd cardhost && node ./node_modules/.bin/ember serve",
+    "start": "cd cardhost && node ./node_modules/ember-cli/bin/ember serve",
     "start-hub": "cd cardhost && ember hub:start",
-    "start-ember": "cd cardhost && HUB_URL=http://localhost:3000 node ./node_modules/.bin/ember s",
-    "test": "mocha ./node-test-runner.js --timeout 10000 && cd cardhost && node ./node_modules/.bin/ember test",
-    "card-tests": "cd cardhost && node ./node_modules/.bin/ember test",
+    "start-ember": "cd cardhost && HUB_URL=http://localhost:3000 node ./node_modules/ember-cli/bin/ember s",
+    "test": "mocha ./node-test-runner.js --timeout 10000 && cd cardhost && node ./node_modules/ember-cli/bin/ember test",
+    "card-tests": "cd cardhost && node ./node_modules/ember-cli/bin/ember test",
     "node-tests": "mocha ./node-test-runner.js --timeout 10000",
     "lint": "eslint . --cache --parser espree"
   },


### PR DESCRIPTION
Commands to start the project was not compatible with some windows shells. We recommend using Git Bash in the quickstart, however if we can make these more compatble, we should.

The error reported:

```
$ HUB_URL=http://localhost:3000 node ./node_modules/.bin/ember s
C:\MYPATH\cardstack\test1\cardhost\node_modules\.bin\ember:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at Module._compile (internal/modules/cjs/loader.js:721:23)
```